### PR TITLE
Sanitize filepath for hashing

### DIFF
--- a/src/eslint.js
+++ b/src/eslint.js
@@ -39,15 +39,16 @@ async function execute(args = []) {
             if (message.severity >= 2) {
 
                 let filePath = path.relative(process.cwd(), file.filePath);
+                const sanitizedfilePath = filePath.replaceAll('\\', '/');
 
                 result.push({
-                    path: filePath,
+                    path: sanitizedfilePath,
                     line: message.line,
                     column: message.column,
                     ruleId: message.ruleId,
                     message: message.message,
                     hash: objectHash.sha1({
-                        filePath,
+                        filePath: sanitizedfilePath,
                         line: message.line,
                         column: message.column, // TODO: optional?
                         ruleId: message.ruleId


### PR DESCRIPTION
To generate a hash that can both be used on windows as well as on *nix based systems this commit replaces the backslash directory separator with a forward-slash separator.

We leave it in the `path` attribute to not interfere with other tools that might depend on it.

**CAVEAT** This will break baselines for Windows-Users! The hashing should be backwards-compatible on *nix platforms but will break on Windows as the windows-path will be sanitized and therefore the hash will change.

Fixes #10 